### PR TITLE
Docs & Code cleanup

### DIFF
--- a/poet/api.go
+++ b/poet/api.go
@@ -4,7 +4,9 @@ package poet
 
 // CodeBlock represent a block of code that can be included in a File
 type CodeBlock interface {
+	// String is the literal string serialization of the code.
 	String() string
+	// GetImports returns the imports required to use this code.
 	GetImports() []Import
 }
 
@@ -13,7 +15,7 @@ type statement struct {
 	Format       string        // Format specifies the format for the code
 	Arguments    []interface{} // Arguments are used within the format string
 	BeforeIndent int           // BeforeIndent augments the indent for the current statement.
-	AfterIndent  int           // AfterIndent specifies ondentation for subsequent statements.
+	AfterIndent  int           // AfterIndent specifies indentation for subsequent statements.
 }
 
 // Identifier represent an instance of a variable
@@ -31,17 +33,23 @@ type IdentifierParameter struct {
 // IdentifierField represent a field in a struct
 type IdentifierField struct {
 	Identifier
-	Tag string // Tag is a
+	Tag string // Tag is a struct field tag, e.g. `json:"foo"`
 }
 
-// Import represent an indivdual import
+// Import represent an individual imported package.
 type Import interface {
+	// GetPackage returns the go import package, like reflect.Type.PkgPath()
 	GetPackage() string
+	// GetAlias returns an alias string to refer to the import package, or the
+	// empty string to omit an import alias.
 	GetAlias() string
 }
 
-// TypeReference represent a specific reference (either an interface, struct or a global)
+// TypeReference represent a specific reference (either an interface, function, struct or global)
 type TypeReference interface {
+	// GetImports returns the imports required to use this type. A struct, for example,
+	// collects all the imports for its fields and itself.
 	GetImports() []Import
+	// GetName returns the go-syntax name of the type.
 	GetName() string
 }

--- a/poet/codewriter.go
+++ b/poet/codewriter.go
@@ -11,7 +11,7 @@ type codeWriter struct {
 	currentIndent int
 }
 
-// NewcodeWriter constructs a new codeWriter
+// newCodeWriter constructs a new codeWriter
 func newCodeWriter() *codeWriter {
 	return &codeWriter{
 		buffer: bytes.Buffer{},
@@ -24,7 +24,8 @@ func (c *codeWriter) WriteCode(code string) {
 	c.buffer.WriteString(code)
 }
 
-// WriteStatement writes a new line of code with the current indentation and augments the identation per the statement.
+// WriteStatement writes a new line of code with the current indentation and augments
+// the indentation per the statement. A newline is appended at the end of the statement.
 func (c *codeWriter) WriteStatement(s statement) {
 	c.currentIndent += s.BeforeIndent
 	c.WriteCode(template(s.Format, s.Arguments...) + "\n")

--- a/poet/codewriter_test.go
+++ b/poet/codewriter_test.go
@@ -1,6 +1,8 @@
 package poet
 
-import . "gopkg.in/check.v1"
+import (
+	. "gopkg.in/check.v1"
+)
 
 type CodeWriterSuite struct{}
 

--- a/poet/functions.go
+++ b/poet/functions.go
@@ -1,6 +1,8 @@
 package poet
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // FuncSpec represents information needed to write a function
 type FuncSpec struct {

--- a/poet/globals.go
+++ b/poet/globals.go
@@ -1,6 +1,8 @@
 package poet
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // VariableGrouping represents a collection of variables and/or constants that will
 // be separated into groups on output.
@@ -84,7 +86,7 @@ func writeGroupAsString(groupName string, vars []*Variable) string {
 
 	buf.WriteString(groupName + " (\n")
 	for _, v := range vars {
-		buf.WriteString("\t" + v.GetDeclaration() + "\n")
+		buf.WriteString("\t" + v.GetDeclaration())
 	}
 	buf.WriteString(")\n")
 	return buf.String()
@@ -107,11 +109,12 @@ func (v *Variable) GetImports() []Import {
 
 // GetDeclaration returns the name and type of this variable, for example: 'foo string'.
 func (v *Variable) GetDeclaration() string {
-	buff := bytes.Buffer{}
-	buff.WriteString(template("$L $T", v.Name, v.Type))
-	buff.WriteString(" = ")
-	buff.WriteString(template(v.Format, v.Args...))
-	return buff.String()
+	w := newCodeWriter()
+	w.WriteStatement(statement{
+		Format:    "$L $T = " + v.Format,
+		Arguments: append([]interface{}{v.Name, v.Type}, v.Args...),
+	})
+	return w.String()
 }
 
 func (v *Variable) String() string {
@@ -122,7 +125,6 @@ func (v *Variable) String() string {
 		buff.WriteString("var ")
 	}
 	buff.WriteString(v.GetDeclaration())
-	buff.WriteString("\n")
 
 	return buff.String()
 }

--- a/poet/imports.go
+++ b/poet/imports.go
@@ -2,7 +2,7 @@ package poet
 
 import (
 	"bytes"
-	"strings"
+	"path"
 )
 
 // ImportSpec implements Import to represent an imported go package
@@ -26,11 +26,7 @@ func (i *ImportSpec) getQualifier() string {
 	} else {
 		// the package may contain slashes, so only write the base name of the package,
 		// not the full package
-		pkg := i.Package
-		if ndx := strings.LastIndex(pkg, "/"); ndx != -1 {
-			pkg = pkg[ndx+1:]
-		}
-		result.WriteString(pkg)
+		result.WriteString(path.Base(i.Package))
 	}
 	result.WriteString(".")
 

--- a/poet/imports_test.go
+++ b/poet/imports_test.go
@@ -1,6 +1,8 @@
 package poet
 
-import . "gopkg.in/check.v1"
+import (
+	. "gopkg.in/check.v1"
+)
 
 type ImportsSuite struct{}
 

--- a/poet/methods.go
+++ b/poet/methods.go
@@ -1,6 +1,8 @@
 package poet
 
-import "bytes"
+import (
+	"bytes"
+)
 
 // MethodSpec represents a method, with a receiver name and type.
 type MethodSpec struct {

--- a/poet/template.go
+++ b/poet/template.go
@@ -3,11 +3,15 @@ package poet
 import (
 	"bytes"
 	"fmt"
-	"strings"
 )
 
 const templatingChar = '$'
 
+// template write go code based on a format string with arguments.
+//
+// $L replaces with the literal value of the argument (%v).
+// $S replaces with the quoted string value of the argument (%q).
+// $T argument must be a TypeReference; it replaces with the TypeRef's GetName().
 func template(format string, args ...interface{}) string {
 	var buffer bytes.Buffer
 
@@ -19,17 +23,16 @@ func template(format string, args ...interface{}) string {
 				panic(fmt.Sprintf("Not enough arguments for format string ('%s'), got %d", format, len(args)))
 			}
 
+			a := args[currentArg]
 			switch format[i+1] {
 			case 'L':
-				buffer.WriteString(fmt.Sprintf("%v", args[currentArg]))
-				break
-			case 'T':
-				buffer.WriteString(getQualifiedNameFromArg(args[currentArg]))
+				buffer.WriteString(fmt.Sprintf("%v", a))
 				break
 			case 'S':
-				buffer.WriteString("\"")
-				buffer.WriteString(strings.Replace(args[currentArg].(string), "\"", "\\\"", -1))
-				buffer.WriteString("\"")
+				buffer.WriteString(fmt.Sprintf("%q", fmt.Sprintf("%v", a)))
+				break
+			case 'T':
+				buffer.WriteString(getQualifiedNameFromArg(a))
 				break
 			default:
 				panic(fmt.Sprintf("Unrecognized templating character in format string ('%s')", format))

--- a/poet/template_test.go
+++ b/poet/template_test.go
@@ -32,6 +32,12 @@ func (s *TemplateSuite) TestTemplateWithString(c *C) {
 	c.Assert(actual, Equals, expected)
 }
 
+func (s *TemplateSuite) TestTemplateWithIntLiterals(c *C) {
+	expected := "literal 1 string \"2\" type int"
+	actual := template("literal $L string $S type $T", 1, 2, TypeReferenceFromInstance(3))
+	c.Assert(actual, Equals, expected)
+}
+
 func (s *TemplateSuite) TestTemplatePanicsWithNotEnoughArgs(c *C) {
 	defer func() {
 		if r := recover(); r != nil {

--- a/poet/types_test.go
+++ b/poet/types_test.go
@@ -93,30 +93,6 @@ func (s *TypeSuite) TestMapImports(c *C) {
 	c.Assert(actual, DeepEquals, expected)
 }
 
-func (s *TypeSuite) TestPrimitive(c *C) {
-	expected := "int"
-	typeRef := Int
-	actual := typeRef.GetName()
-
-	c.Assert(actual, Equals, expected)
-}
-
-func (s *TypeSuite) TestBoolean(c *C) {
-	expected := "bool"
-	typeRef := Bool
-	actual := typeRef.GetName()
-
-	c.Assert(actual, Equals, expected)
-}
-
-func (s *TypeSuite) TestByte(c *C) {
-	expected := "byte"
-	typeRef := Byte
-	actual := typeRef.GetName()
-
-	c.Assert(actual, Equals, expected)
-}
-
 func (s *TypeSuite) TestArray(c *C) {
 	expected := "[]int"
 	typeRef := TypeReferenceFromInstance([]int{})
@@ -166,4 +142,90 @@ func (s *TypeSuite) TestTypeReferencePanicsWithNilInstance(c *C) {
 
 	TypeReferenceFromInstance(nil)
 	c.Fail()
+}
+
+func (s *TypeSuite) TestTypePrimitives(c *C) {
+	for _, test := range []struct {
+		ref  TypeReference
+		name string
+	}{
+		{
+			String,
+			"string",
+		},
+		{
+			Bool,
+			"bool",
+		},
+		{
+			Int,
+			"int",
+		},
+		{
+			Int8,
+			"int8",
+		},
+		{
+			Int16,
+			"int16",
+		},
+		{
+			Int32,
+			"int32",
+		},
+		{
+			Int64,
+			"int64",
+		},
+		{
+			Uint,
+			"uint",
+		},
+		{
+			Uint8,
+			"uint8",
+		},
+		{
+			Uint16,
+			"uint16",
+		},
+		{
+			Uint32,
+			"uint32",
+		},
+		{
+			Uint64,
+			"uint64",
+		},
+		{
+			Uintptr,
+			"uintptr",
+		},
+		{
+			Float32,
+			"float32",
+		},
+		{
+			Float64,
+			"float64",
+		},
+		{
+			Complex64,
+			"complex64",
+		},
+		{
+			Complex128,
+			"complex128",
+		},
+		{
+			Byte,
+			"byte",
+		},
+		{
+			Rune,
+			"rune",
+		},
+	} {
+		c.Check(test.ref.GetName(), Equals, test.name)
+	}
 }


### PR DESCRIPTION
- More API documentation
- Refactor FileSpec code to use one codeWriter
- Typos and other small standardization, run a formatter.

@dpolansky I hope this isn't too intrusive! Note that there's no behavior change in any of the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpolansky/go-poet/8)
<!-- Reviewable:end -->
