### PR TITLE
Refactor globals to use statements

### DIFF
--- a/poet/api.go
+++ b/poet/api.go
@@ -10,8 +10,8 @@ type CodeBlock interface {
 	GetImports() []Import
 }
 
-// statement represent a templated line of code.
-type statement struct {
+// Statement represent a templated line of code.
+type Statement struct {
 	Format       string        // Format specifies the format for the code
 	Arguments    []interface{} // Arguments are used within the format string
 	BeforeIndent int           // BeforeIndent augments the indent for the current statement.

--- a/poet/codewriter.go
+++ b/poet/codewriter.go
@@ -2,7 +2,6 @@ package poet
 
 import (
 	"bytes"
-	"fmt"
 	"strings"
 )
 
@@ -19,20 +18,20 @@ func newCodeWriter() *codeWriter {
 	}
 }
 
-// WriteComment writes a comment, which prepends "// " at the beginning of each line of the comment.
-func (c *codeWriter) WriteComment(comment string) {
-	c.buffer.WriteString(fmt.Sprintf("// %s\n", strings.Replace(comment, "\n", "\n// ", -1)))
-}
-
 // WriteCode writes code at the given indentation
 func (c *codeWriter) WriteCode(code string) {
 	c.buffer.WriteString(strings.Repeat("\t", c.currentIndent))
 	c.buffer.WriteString(code)
 }
 
+// WriteCodeBlock writes a code block at the given indentation
+func (c *codeWriter) WriteCodeBlock(block CodeBlock) {
+	c.WriteCode(block.String())
+}
+
 // WriteStatement writes a new line of code with the current indentation and augments
 // the indentation per the statement. A newline is appended at the end of the statement.
-func (c *codeWriter) WriteStatement(s statement) {
+func (c *codeWriter) WriteStatement(s Statement) {
 	c.currentIndent += s.BeforeIndent
 	c.WriteCode(template(s.Format, s.Arguments...) + "\n")
 	c.currentIndent += s.AfterIndent
@@ -41,4 +40,13 @@ func (c *codeWriter) WriteStatement(s statement) {
 // String gives a string with the code
 func (c *codeWriter) String() string {
 	return c.buffer.String()
+}
+
+func newStatement(beforeIndent, afterIndent int, format string, args ...interface{}) Statement {
+	return Statement{
+		BeforeIndent: beforeIndent,
+		AfterIndent:  afterIndent,
+		Format:       format,
+		Arguments:    args,
+	}
 }

--- a/poet/codewriter.go
+++ b/poet/codewriter.go
@@ -50,3 +50,14 @@ func newStatement(beforeIndent, afterIndent int, format string, args ...interfac
 		Arguments:    args,
 	}
 }
+
+// Appends two Statements without a newline.
+func appendStatements(first, second Statement) Statement {
+	args := append(first.Arguments, second.Arguments...)
+	return Statement{
+		BeforeIndent: first.BeforeIndent,
+		AfterIndent:  second.AfterIndent,
+		Format:       first.Format + second.Format,
+		Arguments:    args,
+	}
+}

--- a/poet/codewriter_test.go
+++ b/poet/codewriter_test.go
@@ -19,7 +19,7 @@ func (f *CodeWriterSuite) TestCodeWriterSingleCode(c *C) {
 
 func (f *CodeWriterSuite) TestCodeWriterSingleStatement(c *C) {
 	expected := "this is a test\n"
-	s := statement{
+	s := Statement{
 		Format: "this is a test",
 	}
 	writer := &codeWriter{}
@@ -31,7 +31,7 @@ func (f *CodeWriterSuite) TestCodeWriterSingleStatement(c *C) {
 
 func (f *CodeWriterSuite) TestCodeWriterPreindentStatement(c *C) {
 	expected := "\t\tthis is a test\n"
-	s := statement{
+	s := Statement{
 		Format:       "this is a test",
 		BeforeIndent: 2,
 	}
@@ -49,19 +49,19 @@ func (f *CodeWriterSuite) TestCodeWriterMixedIndentStatement(c *C) {
 		"\tbut back\n"
 
 	writer := &codeWriter{}
-	writer.WriteStatement(statement{
+	writer.WriteStatement(Statement{
 		Format:       "this is a test",
 		BeforeIndent: 2,
 	})
-	writer.WriteStatement(statement{
+	writer.WriteStatement(Statement{
 		Format:       "still going",
 		BeforeIndent: -1,
 	})
-	writer.WriteStatement(statement{
+	writer.WriteStatement(Statement{
 		Format:       "gone",
 		BeforeIndent: -1,
 	})
-	writer.WriteStatement(statement{
+	writer.WriteStatement(Statement{
 		Format:       "but back",
 		BeforeIndent: 1,
 	})
@@ -70,23 +70,21 @@ func (f *CodeWriterSuite) TestCodeWriterMixedIndentStatement(c *C) {
 	c.Assert(actual, Equals, expected)
 }
 
-func (f *CodeWriterSuite) TestCodeWriterComment(c *C) {
-	expected := "// This is a comment\n"
-
+func (f *CodeWriterSuite) TestCodeWriterCodeBlock(c *C) {
+	expected := "" +
+		"type foo struct {\n" +
+		"}\n"
 	writer := &codeWriter{}
-	writer.WriteComment("This is a comment")
+	writer.WriteCodeBlock(NewStructSpec("foo"))
 	actual := writer.String()
 
 	c.Assert(actual, Equals, expected)
 }
 
-func (f *CodeWriterSuite) TestCodeWriterMultiLineComment(c *C) {
-	expected := "// This is\n" +
-		"// a multi\n" +
-		"// line comment\n"
-
+func (f *CodeWriterSuite) TestCodeWriterNewStatement(c *C) {
+	expected := "this is a test\n"
 	writer := &codeWriter{}
-	writer.WriteComment("This is\na multi\nline comment")
+	writer.WriteStatement(newStatement(0, 0, "$L $L $L $L", "this", "is", "a", "test"))
 	actual := writer.String()
 
 	c.Assert(actual, Equals, expected)

--- a/poet/codewriter_test.go
+++ b/poet/codewriter_test.go
@@ -89,3 +89,63 @@ func (f *CodeWriterSuite) TestCodeWriterNewStatement(c *C) {
 
 	c.Assert(actual, Equals, expected)
 }
+
+func (f *CodeWriterSuite) TestCodeWriterAppendStatements(c *C) {
+	expected := Statement{
+		Format:       "var $L $T",
+		Arguments:    []interface{}{"c", Int},
+		BeforeIndent: 0,
+		AfterIndent:  1,
+	}
+	first := Statement{
+		Format:    "var $L ",
+		Arguments: []interface{}{"c"},
+	}
+	second := Statement{
+		Format:       "$T",
+		Arguments:    []interface{}{Int},
+		BeforeIndent: -1,
+		AfterIndent:  1,
+	}
+	actual := appendStatements(first, second)
+
+	c.Assert(actual, DeepEquals, expected)
+}
+
+func (f *CodeWriterSuite) TestCodeWriterAppendStatementsEmptyFirst(c *C) {
+	expected := Statement{
+		Format:       "$T",
+		Arguments:    []interface{}{Int},
+		BeforeIndent: 0,
+		AfterIndent:  1,
+	}
+	first := Statement{}
+	second := Statement{
+		Format:       "$T",
+		Arguments:    []interface{}{Int},
+		BeforeIndent: -1,
+		AfterIndent:  1,
+	}
+	actual := appendStatements(first, second)
+
+	c.Assert(actual, DeepEquals, expected)
+}
+
+func (f *CodeWriterSuite) TestCodeWriterAppendStatementsEmptySecond(c *C) {
+	expected := Statement{
+		Format:       "var $L",
+		Arguments:    []interface{}{"c"},
+		BeforeIndent: -1,
+		AfterIndent:  0,
+	}
+	first := Statement{
+		Format:       "var $L",
+		Arguments:    []interface{}{"c"},
+		BeforeIndent: -1,
+		AfterIndent:  1,
+	}
+	second := Statement{}
+	actual := appendStatements(first, second)
+
+	c.Assert(actual, DeepEquals, expected)
+}

--- a/poet/comment.go
+++ b/poet/comment.go
@@ -1,0 +1,43 @@
+package poet
+
+import (
+	"strings"
+)
+
+var _ CodeBlock = (*Comment)(nil)
+
+// Comment represents a comment and implements CodeBlock. Multiline comments
+// are supported, with '// ' being prepended to each line.
+type Comment string
+
+// GetImports returns nil.
+func (c Comment) GetImports() []Import {
+	return nil
+}
+
+// String returns a string with all lines prepended with '// '
+func (c Comment) String() string {
+	w := newCodeWriter()
+	for _, s := range c.GetStatements() {
+		w.WriteStatement(s)
+	}
+	return w.String()
+}
+
+// GetStatements returns the comment as statements prepended with '// '.
+func (c Comment) GetStatements() []Statement {
+	if string(c) == "" {
+		return nil
+	}
+
+	lines := strings.Split(string(c), "\n")
+	statements := make([]Statement, len(lines))
+	for i, line := range lines {
+		if line != "" {
+			statements[i] = newStatement(0, 0, "// $L", line)
+		} else {
+			statements[i] = newStatement(0, 0, "//")
+		}
+	}
+	return statements
+}

--- a/poet/comment_test.go
+++ b/poet/comment_test.go
@@ -1,0 +1,41 @@
+package poet
+
+import (
+	. "gopkg.in/check.v1"
+)
+
+type CommentSuite struct{}
+
+var _ = Suite(&CommentSuite{})
+
+func (s *CommentSuite) TestCommentEmpty(c *C) {
+	comment := Comment("")
+	expected := ""
+
+	c.Assert(comment.String(), Equals, expected)
+	c.Assert(comment.GetImports(), IsNil)
+}
+
+func (s *CommentSuite) TestCommentSimgleLine(c *C) {
+	comment := Comment("this is a comment")
+	expected := "// this is a comment\n"
+
+	c.Assert(comment.String(), Equals, expected)
+	c.Assert(comment.GetImports(), IsNil)
+}
+
+func (s *CommentSuite) TestCommentMultiLine(c *C) {
+	comment := Comment("this\nis\n a\n  comment")
+	expected := "// this\n// is\n//  a\n//   comment\n"
+
+	c.Assert(comment.String(), Equals, expected)
+	c.Assert(comment.GetImports(), IsNil)
+}
+
+func (s *CommentSuite) TestCommentEmptyLines(c *C) {
+	comment := Comment("this is\n\na comment")
+	expected := "// this is\n//\n// a comment\n"
+
+	c.Assert(comment.String(), Equals, expected)
+	c.Assert(comment.GetImports(), IsNil)
+}

--- a/poet/files.go
+++ b/poet/files.go
@@ -109,13 +109,9 @@ func (f *FileSpec) FileComment(comment string) *FileSpec {
 
 func (f *FileSpec) writeHeader(w *codeWriter) {
 	if f.Comment != "" {
-		w.WriteComment(f.Comment)
+		w.WriteCodeBlock(Comment(f.Comment))
 	}
-
-	w.WriteStatement(statement{
-		Format:    "package $L\n",
-		Arguments: []interface{}{f.Package},
-	})
+	w.WriteStatement(newStatement(0, 0, "package $L\n", f.Package))
 }
 
 func (f *FileSpec) writeImports(w *codeWriter) {
@@ -124,35 +120,28 @@ func (f *FileSpec) writeImports(w *codeWriter) {
 		return
 	}
 
-	w.WriteStatement(statement{
-		Format:      "import (",
-		AfterIndent: 1,
-	})
+	w.WriteStatement(newStatement(0, 1, "import ("))
 	for _, i := range imports {
 		var prefix string
 		if i.GetAlias() != "" {
 			prefix = i.GetAlias() + " "
 		}
-		w.WriteStatement(statement{
-			Format:    "$L$S",
-			Arguments: []interface{}{prefix, i.GetPackage()},
-		})
+		w.WriteStatement(newStatement(0, 0, "$L$S", prefix, i.GetPackage()))
 	}
-	w.WriteStatement(statement{
-		Format:       ")\n",
-		BeforeIndent: -1,
-	})
+	w.WriteStatement(newStatement(-1, 0, ")\n"))
 }
 
 func (f *FileSpec) writeInitFunc(w *codeWriter) {
 	if f.Init != nil {
-		w.WriteStatement(statement{Format: f.Init.String()})
+		w.WriteCodeBlock(f.Init)
+		w.WriteStatement(Statement{})
 	}
 }
 
 func (f *FileSpec) writeCodeBlocks(w *codeWriter) {
 	for _, blk := range f.CodeBlocks {
-		w.WriteStatement(statement{Format: blk.String()})
+		w.WriteCodeBlock(blk)
+		w.WriteStatement(Statement{})
 	}
 }
 

--- a/poet/files.go
+++ b/poet/files.go
@@ -70,8 +70,7 @@ func (f *FileSpec) GlobalVariable(name string, typ TypeReference, format string,
 			Type: typ,
 		},
 		Constant: false,
-		Format:   format,
-		Args:     args,
+		Value:    newStatement(0, 0, format, args...),
 	}
 	f.CodeBlocks = append(f.CodeBlocks, v)
 	return f
@@ -86,8 +85,7 @@ func (f *FileSpec) GlobalConstant(name string, typ TypeReference, format string,
 			Type: typ,
 		},
 		Constant: true,
-		Format:   format,
-		Args:     args,
+		Value:    newStatement(0, 0, format, args...),
 	}
 	f.CodeBlocks = append(f.CodeBlocks, v)
 	return f

--- a/poet/files_test.go
+++ b/poet/files_test.go
@@ -212,14 +212,18 @@ func (f *FilesSuite) TestFileGlobalVariableGrouping(c *C) {
 			Name: "c",
 			Type: TypeReferenceFromInstance(1),
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: true,
+		Constant: true,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
 	}
 	variableB := &Variable{
 		Identifier: Identifier{
 			Name: "d",
 			Type: TypeReferenceFromInstance(1),
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: false,
+		Constant: false,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
 	}
 
 	fspec := NewFileSpec("foo")

--- a/poet/files_test.go
+++ b/poet/files_test.go
@@ -3,10 +3,10 @@ package poet
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 
 	. "gopkg.in/check.v1"
-	"strings"
 )
 
 func _(t *testing.T) { TestingT(t) }
@@ -125,7 +125,7 @@ func (f *FilesSuite) TestFileRepeatedImports(c *C) {
 		"package foo\n" +
 		"\n" +
 		"import (\n" +
-			"\t_ \"bytes\"\n" +
+		"\t_ \"bytes\"\n" +
 		")\n" +
 		"\n"
 

--- a/poet/functions_test.go
+++ b/poet/functions_test.go
@@ -112,7 +112,7 @@ func (f *FunctionsSuite) TestFunctionComment(c *C) {
 	c.Assert(actual, Equals, expected)
 }
 
-func (f *FunctionsSuite) TestBlockStatements(c *C) {
+func (f *FunctionsSuite) TestFunctionBlockStatements(c *C) {
 	expected := "" +
 		"func foo() {\n" +
 		"\tfor i:=0; i<5; i++ {\n" +
@@ -125,6 +125,21 @@ func (f *FunctionsSuite) TestBlockStatements(c *C) {
 	fnc.Statement("$T($L)", TypeReferenceFromInstance(fmt.Println), "i")
 	fnc.BlockEnd()
 	actual := fnc.String()
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *FunctionsSuite) TestFunctionAnonymous(c *C) {
+	expected := "" +
+		"func (name string) string {\n" +
+		"\treturn fmt.Sprintf(\"hello %s\", name)\n" +
+		"}\n"
+
+	fnc := NewFuncSpec("")
+	fnc.Parameter("name", String)
+	fnc.Statement("return $T($S, $L)", TypeReferenceFromInstance(fmt.Sprintf), "hello %s", "name")
+	fnc.ResultParameter("", String)
+	actual := fnc.String()
+
 	c.Assert(actual, Equals, expected)
 }
 

--- a/poet/globals.go
+++ b/poet/globals.go
@@ -2,6 +2,7 @@ package poet
 
 import (
 	"bytes"
+	"fmt"
 )
 
 // VariableGrouping represents a collection of variables and/or constants that will
@@ -110,21 +111,17 @@ func (v *Variable) GetImports() []Import {
 // GetDeclaration returns the name and type of this variable, for example: 'foo string'.
 func (v *Variable) GetDeclaration() string {
 	w := newCodeWriter()
-	w.WriteStatement(statement{
-		Format:    "$L $T = " + v.Format,
-		Arguments: append([]interface{}{v.Name, v.Type}, v.Args...),
-	})
+	args := append([]interface{}{v.Name, v.Type}, v.Args...)
+	w.WriteStatement(newStatement(0, 0, "$L $T = "+v.Format, args...))
 	return w.String()
 }
 
 func (v *Variable) String() string {
-	buff := bytes.Buffer{}
+	var prefix string
 	if v.Constant {
-		buff.WriteString("const ")
+		prefix = "const"
 	} else {
-		buff.WriteString("var ")
+		prefix = "var"
 	}
-	buff.WriteString(v.GetDeclaration())
-
-	return buff.String()
+	return fmt.Sprintf("%s %s", prefix, v.GetDeclaration())
 }

--- a/poet/globals_test.go
+++ b/poet/globals_test.go
@@ -17,9 +17,54 @@ func (f *VariablesSuite) TestVariable(c *C) {
 	variable := &Variable{
 		Identifier: Identifier{
 			Name: "c",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1},
+		Value: newStatement(0, 0, "$L", 1),
+	}
+	actual := variable.String()
+
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *VariablesSuite) TestVariableNoValue(c *C) {
+	expected := "var c int\n"
+	variable := &Variable{
+		Identifier: Identifier{
+			Name: "c",
+			Type: Int,
+		},
+	}
+	actual := variable.String()
+
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *VariablesSuite) TestVariableWithComment(c *C) {
+	expected := "// c is an int\n" +
+		"// with value 1\n" +
+		"var c int = 1\n"
+	variable := &Variable{
+		Comment: "c is an int\nwith value 1",
+		Identifier: Identifier{
+			Name: "c",
+			Type: Int,
+		},
+		Value: newStatement(0, 0, "$L", 1),
+	}
+	actual := variable.String()
+
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *VariablesSuite) TestVariableNoValueWithComment(c *C) {
+	expected := "// c is an int\n" +
+		"var c int\n"
+	variable := &Variable{
+		Comment: "c is an int",
+		Identifier: Identifier{
+			Name: "c",
+			Type: Int,
+		},
 	}
 	actual := variable.String()
 
@@ -31,21 +76,25 @@ func (f *VariablesSuite) TestVariableGrouping(c *C) {
 		"\tc int = 1\n" +
 		"\td int = 1\n" +
 		")\n"
+
 	variableA := &Variable{
 		Identifier: Identifier{
 			Name: "c",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1},
+		InGroup: true,
+		Value:   newStatement(0, 0, "$L", 1),
 	}
 	variableB := &Variable{
 		Identifier: Identifier{
 			Name: "d",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1},
+		InGroup: true,
+		Value:   newStatement(0, 0, "$L", 1),
 	}
 	variableGrouping := VariableGrouping{Variables: []*Variable{variableA, variableB}}
+
 	actual := variableGrouping.String()
 
 	c.Assert(actual, Equals, expected)
@@ -56,12 +105,12 @@ func (f *VariablesSuite) TestConstant(c *C) {
 	variable := &Variable{
 		Identifier: Identifier{
 			Name: "c",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: true,
+		Constant: true,
+		Value:    newStatement(0, 0, "$L", 1),
 	}
 	actual := variable.String()
-
 	c.Assert(actual, Equals, expected)
 }
 
@@ -70,19 +119,59 @@ func (f *VariablesSuite) TestConstantGrouping(c *C) {
 		"\tc int = 1\n" +
 		"\td int = 1\n" +
 		")\n"
+
 	variableA := &Variable{
 		Identifier: Identifier{
 			Name: "c",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: true,
+		Constant: true,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
 	}
 	variableB := &Variable{
 		Identifier: Identifier{
 			Name: "d",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: true,
+		Constant: true,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
+	}
+	variableGrouping := VariableGrouping{Variables: []*Variable{variableA, variableB}}
+	actual := variableGrouping.String()
+
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *VariablesSuite) TestConstantGroupingWithComment(c *C) {
+	expected := "const (\n" +
+		"\t// c has a value of 1\n" +
+		"\tc int = 1\n" +
+		"\t// d has\n" +
+		"\t// no value yet\n" +
+		"\td int\n" +
+		")\n"
+
+	variableA := &Variable{
+		Comment: "c has a value of 1",
+		Identifier: Identifier{
+			Name: "c",
+			Type: Int,
+		},
+		Constant: true,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
+	}
+	variableB := &Variable{
+		Comment: "d has\n" +
+			"no value yet",
+		Identifier: Identifier{
+			Name: "d",
+			Type: Int,
+		},
+		Constant: true,
+		InGroup:  true,
 	}
 	variableGrouping := VariableGrouping{Variables: []*Variable{variableA, variableB}}
 	actual := variableGrouping.String()
@@ -97,8 +186,8 @@ func (f *VariablesSuite) TestGroupingWithAttachedConstants(c *C) {
 		")\n"
 
 	variableGrouping := &VariableGrouping{}
-	variableGrouping.Constant("c", TypeReferenceFromInstance(1), "$L", 1)
-	variableGrouping.Constant("d", TypeReferenceFromInstance(1), "$L", 1)
+	variableGrouping.Constant("c", Int, "$L", 1)
+	variableGrouping.Constant("d", Int, "$L", 1)
 
 	actual := variableGrouping.String()
 	c.Assert(actual, Equals, expected)
@@ -111,8 +200,8 @@ func (f *VariablesSuite) TestGroupingWithAttachedVariables(c *C) {
 		")\n"
 
 	variableGrouping := &VariableGrouping{}
-	variableGrouping.Variable("c", TypeReferenceFromInstance(1), "$L", 1)
-	variableGrouping.Variable("d", TypeReferenceFromInstance(1), "$L", 1)
+	variableGrouping.Variable("c", Int, "$L", 1)
+	variableGrouping.Variable("d", Int, "$L", 1)
 
 	actual := variableGrouping.String()
 	c.Assert(actual, Equals, expected)
@@ -128,8 +217,25 @@ func (f *VariablesSuite) TestGroupingWithAttachedMixed(c *C) {
 		")\n"
 
 	variableGrouping := &VariableGrouping{}
-	variableGrouping.Constant("c", TypeReferenceFromInstance(1), "$L", 1)
-	variableGrouping.Variable("d", TypeReferenceFromInstance(1), "$L", 1)
+	variableGrouping.Constant("c", Int, "$L", 1)
+	variableGrouping.Variable("d", Int, "$L", 1)
+
+	actual := variableGrouping.String()
+	c.Assert(actual, Equals, expected)
+}
+
+func (f *VariablesSuite) TestGroupingWithAttachedMixedNoValue(c *C) {
+	expected := "const (\n" +
+		"\tc int = 1\n" +
+		")\n" +
+		"\n" +
+		"var (\n" +
+		"\td int\n" +
+		")\n"
+
+	variableGrouping := &VariableGrouping{}
+	variableGrouping.Constant("c", Int, "$L", 1)
+	variableGrouping.Variable("d", Int, "")
 
 	actual := variableGrouping.String()
 	c.Assert(actual, Equals, expected)
@@ -143,19 +249,23 @@ func (f *VariablesSuite) TestConstantGroupingMixed(c *C) {
 		"var (\n" +
 		"\td int = 1\n" +
 		")\n"
+
 	variableA := &Variable{
 		Identifier: Identifier{
 			Name: "c",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: true,
+		Constant: true,
+		InGroup:  true,
+		Value:    newStatement(0, 0, "$L", 1),
 	}
 	variableB := &Variable{
 		Identifier: Identifier{
 			Name: "d",
-			Type: TypeReferenceFromInstance(1),
+			Type: Int,
 		},
-		Format: "$L", Args: []interface{}{1}, Constant: false,
+		InGroup: true,
+		Value:   newStatement(0, 0, "$L", 1),
 	}
 	variableGrouping := VariableGrouping{Variables: []*Variable{variableA, variableB}}
 	actual := variableGrouping.String()

--- a/poet/interfaces.go
+++ b/poet/interfaces.go
@@ -32,7 +32,7 @@ func (i *InterfaceSpec) EmbedInterface(interfaceType TypeReference) *InterfaceSp
 	return i
 }
 
-// GetImports returns Import's used by the interface
+// GetImports returns Imports used by the interface
 func (i *InterfaceSpec) GetImports() []Import {
 	packages := []Import{}
 
@@ -56,39 +56,23 @@ func (i *InterfaceSpec) GetName() string {
 func (i *InterfaceSpec) String() string {
 	writer := newCodeWriter()
 	if i.Comment != "" {
-		writer.WriteComment(i.Comment)
+		writer.WriteCodeBlock(Comment(i.Comment))
 	}
-	writer.WriteStatement(statement{
-		Format:      "type $L interface {",
-		Arguments:   []interface{}{i.Name},
-		AfterIndent: 1,
-	})
+	writer.WriteStatement(newStatement(0, 1, "type $L interface {", i.Name))
 
 	for _, interf := range i.EmbeddedInterfaces {
-		writer.WriteStatement(statement{
-			Format:    "$L",
-			Arguments: []interface{}{interf.GetName()},
-		})
+		writer.WriteStatement(newStatement(0, 0, "$L", interf.GetName()))
 	}
 
 	for _, method := range i.Methods {
 		if method.Comment != "" {
-			writer.WriteStatement(statement{
-				Format:    "// $L",
-				Arguments: []interface{}{method.Comment},
-			})
+			writer.WriteStatement(newStatement(0, 0, "// $L", method.Comment))
 		}
 		signature, args := method.Signature()
-		writer.WriteStatement(statement{
-			Format:    signature,
-			Arguments: args,
-		})
+		writer.WriteStatement(newStatement(0, 0, signature, args...))
 	}
 
-	writer.WriteStatement(statement{
-		Format:       "}",
-		BeforeIndent: -1,
-	})
+	writer.WriteStatement(newStatement(-1, 0, "}"))
 
 	return writer.String()
 }

--- a/poet/methods.go
+++ b/poet/methods.go
@@ -1,7 +1,7 @@
 package poet
 
 import (
-	"bytes"
+	"fmt"
 )
 
 // MethodSpec represents a method, with a receiver name and type.
@@ -27,36 +27,16 @@ func NewMethodSpec(name, receiverName string, receiver TypeReference) *MethodSpe
 func (m *MethodSpec) String() string {
 	writer := newCodeWriter()
 
-	writer.WriteStatement(m.createSignature())
+	signature, args := m.Signature()
+	format := fmt.Sprintf("func ($L $T) %s {", signature)
+	args = append([]interface{}{m.ReceiverName, m.Receiver}, args...)
+	writer.WriteStatement(newStatement(0, 1, format, args...))
 
 	for _, st := range m.Statements {
 		writer.WriteStatement(st)
 	}
 
-	writer.WriteStatement(statement{
-		BeforeIndent: -1,
-		Format:       "}",
-	})
+	writer.WriteStatement(newStatement(-1, 0, "}"))
 
 	return writer.String()
-}
-
-func (m *MethodSpec) createSignature() statement {
-	formatStr := bytes.Buffer{}
-	signature, args := m.Signature()
-
-	formatStr.WriteString("func ")
-	formatStr.WriteString("(")
-	formatStr.WriteString(m.ReceiverName)
-	formatStr.WriteString(" ")
-	formatStr.WriteString(m.Receiver.GetName())
-	formatStr.WriteString(") ")
-	formatStr.WriteString(signature)
-	formatStr.WriteString(" {")
-
-	return statement{
-		AfterIndent: 1,
-		Format:      formatStr.String(),
-		Arguments:   args,
-	}
 }

--- a/poet/structs.go
+++ b/poet/structs.go
@@ -38,14 +38,10 @@ func (s *StructSpec) String() string {
 	writer := newCodeWriter()
 
 	if s.Comment != "" {
-		writer.WriteComment(s.Comment)
+		writer.WriteCodeBlock(Comment(s.Comment))
 	}
 
-	writer.WriteStatement(statement{
-		Format:      "type $L struct {",
-		Arguments:   []interface{}{s.Name},
-		AfterIndent: 1,
-	})
+	writer.WriteStatement(newStatement(0, 1, "type $L struct {", s.Name))
 
 	for _, field := range s.Fields {
 		var format string
@@ -58,23 +54,17 @@ func (s *StructSpec) String() string {
 			format = "$L $T"
 		}
 
-		writer.WriteStatement(statement{
-			Format:    format,
-			Arguments: arguments,
-		})
+		writer.WriteStatement(newStatement(0, 0, format, arguments...))
 	}
-
-	writer.WriteStatement(statement{
-		Format:       "}",
-		BeforeIndent: -1,
-	})
+	writer.WriteStatement(newStatement(-1, 0, "}"))
 
 	if len(s.Methods) != 0 {
-		writer.WriteCode("\n")
+		writer.WriteStatement(Statement{})
 	}
 
 	for _, method := range s.Methods {
-		writer.WriteCode(method.String() + "\n")
+		writer.WriteCodeBlock(method)
+		writer.WriteStatement(Statement{})
 	}
 	return writer.String()
 }

--- a/poet/typealias.go
+++ b/poet/typealias.go
@@ -37,12 +37,9 @@ func (a *TypeAliasSpec) GetImports() []Import {
 func (a *TypeAliasSpec) String() string {
 	writer := newCodeWriter()
 	if a.Comment != "" {
-		writer.WriteComment(a.Comment)
+		writer.WriteCodeBlock(Comment(a.Comment))
 	}
+	writer.WriteStatement(newStatement(0, 0, "type $T $T", a, a.UnderlyingType))
 
-	writer.WriteStatement(statement{
-		Format:    "type $T $T",
-		Arguments: []interface{}{a, a.UnderlyingType},
-	})
 	return writer.String()
 }

--- a/poet/types.go
+++ b/poet/types.go
@@ -2,11 +2,11 @@ package poet
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"reflect"
 	"runtime"
 	"strings"
-	"errors"
 )
 
 // UnqualifiedPrefix The prefix for type aliases that will be interpreted as unqualified


### PR DESCRIPTION
// This branch has #12 in it as well, so we should merge that first and rebase this. Take a look at the top commit in the meantime for the change in this PR.

Refactor globals to use `Value Statement`. This should actually be a CodeBlock and it will be when I'm done moving things around, but I need to add GetStatements() to the CodeBlock API first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dpolansky/go-poet/13)
<!-- Reviewable:end -->
